### PR TITLE
Fix of Instances pretty print

### DIFF
--- a/30log.lua
+++ b/30log.lua
@@ -21,7 +21,7 @@ baseMt = { __call = function (self,...) return self:new(...) end, __tostring = f
   if _instances[self] then return ('object(of %s):<%s>'):format((rawget(getmetatable(self),'__name') or '?'), _instances[self]) end
   return _classes[self] and ('class(%s):<%s>'):format((rawget(self,'__name') or '?'),_classes[self]) or self
 end}
-class = function(attr)
+local class = function(attr)
   local c = deep_copy(attr) ; _classes[c] = tostring(c);
   c.include = function(self,include) assert(_classes[self], 'Mixins can only be used on classes.'); return deep_copy(include, self, 'function') end
   c.new, c.extends, c.__index, c.__call, c.__tostring = instantiate, extends, c, baseMt.__call, baseMt.__tostring;

--- a/30logclasscommons.lua
+++ b/30logclasscommons.lua
@@ -8,6 +8,7 @@ if common_class ~= false and not common then
   function common.class(name, prototype, parent)
     local klass = class():extends(parent):extends(prototype)
     klass.__init = prototype.init or (parent or {}).init
+    klass.__name = name
     return klass
   end
   function common.instance(class, ...)

--- a/30logclasscommonslocal.lua
+++ b/30logclasscommonslocal.lua
@@ -1,0 +1,14 @@
+local PATH = (... or ''):match("^(.+)%.[^%.]+$") or false
+local class = require( (PATH and PATH.."." or '') .. "30log")
+
+local _M = {}
+_M.class = function(name, prototype, parent)
+	local klass = class():extends(parent):extends(prototype)
+	klass.__init = prototype.init or (parent or {}).init
+	klass.__name = name
+	return klass
+end
+_M.instance = function(class, ...)
+	return class:new(...)
+end
+return _M

--- a/30logclasscommonslocal_test.lua
+++ b/30logclasscommonslocal_test.lua
@@ -1,0 +1,5 @@
+local common = require ('30logclasscommonslocal')
+local class = assert(common.class), assert(common.instance)
+
+_G.common_class = true
+_G.common = common


### PR DESCRIPTION
print(common.instance(common.class("dbClassName",{}))) will be printed as "object(of dbClassName):<table: 0x12345678>" instead of "object(of ?):<table: 0x12345678>"
